### PR TITLE
30/FE-implementing Redux & commented out styling

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -14,5 +14,7 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "warn"
   },
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,8 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.18",
         "@mui/material": "^5.14.18",
+        "@reduxjs/toolkit": "^2.0.1",
+        "@types/react-redux": "^7.1.32",
         "graphql": "^16.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2115,6 +2117,29 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.0",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
@@ -2621,6 +2646,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2687,6 +2721,25 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.32",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.32.tgz",
+      "integrity": "sha512-YJYV0M27cyHHJIacaRsZRx5OETzK8KWjEGnix7UH3ngItYo4It0MUBzU6WNwqnwhbrPw5wx9KXluuoTZ85Gg7A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -4533,6 +4586,15 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6363,6 +6425,19 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.0.tgz",
+      "integrity": "sha512-blLIYmYetpZMET6Q6uCY7Jtl/Im5OBldy+vNPauA8vvsdqyt66oep4EUpAMWNHauTC6xa9JuRPhRB72rY82QGA=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
@@ -6393,6 +6468,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.0.1.tgz",
+      "integrity": "sha512-D72j2ubjgHpvuCiORWkOUxndHJrxDaSolheiz5CO+roz8ka97/4msh2E8F5qay4GawR5vzBt5MkbDHT+Rdy/Wg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -8657,6 +8737,17 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
+    "@reduxjs/toolkit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
+      "requires": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.0",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      }
+    },
     "@remix-run/router": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
@@ -8972,6 +9063,15 @@
         "@types/node": "*"
       }
     },
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
+      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -9038,6 +9138,27 @@
       "dev": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/react-redux": {
+      "version": "7.1.32",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.32.tgz",
+      "integrity": "sha512-YJYV0M27cyHHJIacaRsZRx5OETzK8KWjEGnix7UH3ngItYo4It0MUBzU6WNwqnwhbrPw5wx9KXluuoTZ85Gg7A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      },
+      "dependencies": {
+        "redux": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+          "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+          "requires": {
+            "@babel/runtime": "^7.9.2"
+          }
+        }
       }
     },
     "@types/react-transition-group": {
@@ -10361,6 +10482,11 @@
       "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
       "dev": true
     },
+    "immer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -11678,6 +11804,17 @@
         "prop-types": "^15.6.2"
       }
     },
+    "redux": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.0.tgz",
+      "integrity": "sha512-blLIYmYetpZMET6Q6uCY7Jtl/Im5OBldy+vNPauA8vvsdqyt66oep4EUpAMWNHauTC6xa9JuRPhRB72rY82QGA=="
+    },
+    "redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "requires": {}
+    },
     "regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
@@ -11699,6 +11836,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
+    },
+    "reselect": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.0.1.tgz",
+      "integrity": "sha512-D72j2ubjgHpvuCiORWkOUxndHJrxDaSolheiz5CO+roz8ka97/4msh2E8F5qay4GawR5vzBt5MkbDHT+Rdy/Wg=="
     },
     "resolve": {
       "version": "1.22.8",

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,8 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.18",
     "@mui/material": "^5.14.18",
+    "@reduxjs/toolkit": "^2.0.1",
+    "@types/react-redux": "^7.1.32",
     "graphql": "^16.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/App/store.ts
+++ b/client/src/App/store.ts
@@ -1,10 +1,12 @@
 import { configureStore } from '@reduxjs/toolkit';
+import plantTypeReducer from '../Features/plantType/plantTypeSlice';
 
 
 export const store = configureStore({
   reducer: {
     //add reducer information
     //plantType: plantTypeReducer incase we want to update the state of the plant type from indoor to outdoor
+    plantType: plantTypeReducer
     
   },
 })

--- a/client/src/App/store.ts
+++ b/client/src/App/store.ts
@@ -1,0 +1,15 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+
+export const store = configureStore({
+  reducer: {
+    //add reducer information
+    //plantType: plantTypeReducer incase we want to update the state of the plant type from indoor to outdoor
+    
+  },
+})
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>
+// Inferred type: {plantType: plantTypeState}
+export type AppDispatch = typeof store.dispatch

--- a/client/src/Features/plantType/plantType.ts
+++ b/client/src/Features/plantType/plantType.ts
@@ -1,0 +1,9 @@
+import React from "react";
+import { useAppSelector, useAppDispatch } from "../../Hooks/hooks";
+import { indoor } from "./plantTypeSlice";
+
+export function PlantType() {
+  const type = useAppSelector((state) => state.plantType.value)
+  const dispatch = useAppDispatch;
+
+}

--- a/client/src/Features/plantType/plantType.ts
+++ b/client/src/Features/plantType/plantType.ts
@@ -5,5 +5,4 @@ import { indoor } from "./plantTypeSlice";
 export function PlantType() {
   const type = useAppSelector((state) => state.plantType.value)
   const dispatch = useAppDispatch;
-
 }

--- a/client/src/Features/plantType/plantTypeSlice.ts
+++ b/client/src/Features/plantType/plantTypeSlice.ts
@@ -8,14 +8,12 @@ interface plantTypeState {
   value: boolean
 }
 
-// Define the initial state using that type
 const initialState: plantTypeState = {
   value: false,
 }
 
 export const plantTypeSlice = createSlice({
   name: 'plantType',
-  // `createSlice` will infer the state type from the `initialState` argument
   initialState,
   reducers: {
     indoor: (state) => {

--- a/client/src/Features/plantType/plantTypeSlice.ts
+++ b/client/src/Features/plantType/plantTypeSlice.ts
@@ -10,8 +10,32 @@ interface plantTypeState {
 
 // Define the initial state using that type
 const initialState: plantTypeState = {
-  value: true,
+  value: false,
 }
 
+export const plantTypeSlice = createSlice({
+  name: 'plantType',
+  // `createSlice` will infer the state type from the `initialState` argument
+  initialState,
+  reducers: {
+    indoor: (state) => {
+      state.value = true;
+    },
+    // outdoor: (state) => {
+    //   state.value = false;
+    // },
+    // Use the PayloadAction type to declare the contents of `action.payload`
+    changePlantType: (state, action: PayloadAction<boolean>) => {
+      state.value = action.payload
+    },
+  },
+})
+
+export const { indoor, changePlantType } = plantTypeSlice.actions
+
+// Other code such as selectors can use the imported `RootState` type
+export const selectCount = (state: RootState) => state.plantType.value
+
+export default plantTypeSlice.reducer
 
 

--- a/client/src/Features/plantType/plantTypeSlice.ts
+++ b/client/src/Features/plantType/plantTypeSlice.ts
@@ -1,0 +1,17 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from '../../App/store';
+
+
+
+interface plantTypeState {
+  value: boolean
+}
+
+// Define the initial state using that type
+const initialState: plantTypeState = {
+  value: true,
+}
+
+
+

--- a/client/src/HomePage.tsx
+++ b/client/src/HomePage.tsx
@@ -13,7 +13,7 @@ function HomePage() {
  
   return (
     <>
-  <header id='header'>
+  {/* <header id='header'>
   <nav id= 'nav-bar'>
     <ul>
       <li><a href='/get-started'>Get Started</a></li>
@@ -52,31 +52,7 @@ function HomePage() {
   <img className="feat-container-img" src={lineGraph} />
     <p>EXAMPLE TEXT Receive timely and relevant updates with our smart notification feature. Stay informed about important events, changes, and personalized recommendations, ensuring you never miss a beat.</p>
   </div>
-</div>
-
-  
-
-
-{/* <section id="middle-container">
-  <h1>What is Green Pets</h1>
-  <p>Seamlessly find the perfect houseplants tailored to your local environment with our geolocation-based search feature.</p>
-  <Link to="/get-started" className="btn-primary">Get Started</Link>
-</section>
-
-<section id="bottom-container">
-  <div className="image-container">
-    <img className="product" src={product} />
-    <p>EXAMPLE TEXT Receive timely and relevant updates with our smart notification feature. Stay informed about important events, changes, and personalized recommendations, ensuring you never miss a beat.</p>
-  </div>
-  <div className="image-container">
-    <img className="product" src={product} />
-    <p>EXAMPLE TEXT Experience effortless integration with our seamless feature that allows you to connect and synchronize across multiple platforms. Enjoy a unified and cohesive user experience as you navigate through various functionalities with ease.</p>
-  </div>
-  <div className="image-container">
-    <img className="product" src={product} />
-    <p>EXAMPLE TEXT Uncover information swiftly with our intelligent search feature. Harness the power of advanced algorithms to retrieve accurate and tailored results, making your search experience faster, more precise, and tailored to your needs.</p>
-  </div>
-</section> */}
+</div> */}
     </>
   )
 }

--- a/client/src/Hooks/hooks.ts
+++ b/client/src/Hooks/hooks.ts
@@ -1,0 +1,8 @@
+//rename this file down the road
+import { useDispatch, useSelector } from 'react-redux'
+import type { TypedUseSelectorHook } from 'react-redux'
+import type { RootState, AppDispatch } from '../App/store'
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,4 +1,4 @@
-:root {
+/* :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
@@ -254,4 +254,4 @@ button:focus-visible {
   }
 }
 
-
+ */


### PR DESCRIPTION
## Overview

**task-name**
30/FE-implementing Redux

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
The work here is setting up Redux Toolkit to provide us with a state management down the road. As of now, we aren't currently working or managing any state, but that could change. We also commented out some styling and HTML on `Homepage.tsx` and styling from `index.css` a future PR will have styled components. Please make sure to pull in those changes as well.

You'll notice a folder called `Features` which is the home area for our reducers based on documentation. As well as `Hooks` folder which is the home area for our hooks we are utilizing Redux.

The last new addition to a folder was the `App` folder which is under the `src` directory. Based on documentation, we followed the file structure accordingly, but still good to know in case we want to make changes since other items could be called App.

For documentation. [Here is the doc](https://redux-toolkit.js.org/tutorials/typescript) I followed while setting up. 

For the redux, here is an explanation on the changes.

Right now, we created our `store.ts` file which is the main component for hosting our `plantTypeReducer` which is responsible for managing our state for the `plantType` which is a boolean. We also created our Redux store using the `configureStore` function. Down the road when we are ready to update state, we would _dispatch_ _actions_ to that **reducer**.

```
export const store = configureStore({
  reducer: {
    plantType: plantTypeReducer
  },
})
```

From `plantTypeSlice.ts` we import the following three files. The importance of them is that we are importing the `createSlice` function from the Redux Toolkit and `PayloadAction` for our action payloads. `RootState` is being imported from our `store.ts` file on line 15.

```
import { createSlice } from '@reduxjs/toolkit';
import type { PayloadAction } from '@reduxjs/toolkit';
import { RootState } from '../../App/store';
```

This logic here is just our interface that we are defining a property value with the type of `boolean`.

```
interface plantTypeState {
  value: boolean;
}
```
Here is the logic we are setting the initialState to `false`

```
const initialState: plantTypeState = {
  value: false,
}
```


In the same file we have our `createSlice` function which is being used to create our reducer slice. It's taking an object with the name of the slice, the `initialState` and a set of reducers. Right now, you are seeing two reducers. `Indoor` and `changePlantType`. You might be wondering why there is no "outdoor" reducer, but the logic behind `changePlantType` is essentially doing that. The `indoor` reducer sets the value to `true` and `changePlantType` will take the payload of type boolean and will set the value accordingly.


```
export const plantTypeSlice = createSlice({
  name: 'plantType',
  initialState,
  reducers: {
    indoor: (state) => {
      state.value = true;
    },
    changePlantType: (state, action: PayloadAction<boolean>) => {
      state.value = action.payload;
    },
  },
});
```

Logic behind `Hooks.ts`

The main piece behind these import statements is that is gives us some functions we can utilize from the redux library like `useDispatch` and `useSelector`. 

```
import { useDispatch, useSelector } from 'react-redux';
import type { TypedUseSelectorHook } from 'react-redux';
import type { RootState, AppDispatch } from '../App/store';
```

However, with typescript we'll want to use `useAppSelector` and `useAppDispatch` which you'll see at the bottom of the `Hooks.ts` file. 

```

export const useAppDispatch: () => AppDispatch = useDispatch
export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
```

Per the documentation, this is why. I didn't get heavily researched into the `Hooks.ts` file so let me know if you have questions. My assumption without testing is we'll be importing the hook and invoking the hook in different components. 

For `useSelector`, it saves you the need to type `(state: RootState)` every time
For `useDispatch`, the default `Dispatch` type does not know about thunks. In order to correctly dispatch thunks, you need to use the specific customized `AppDispatch` type from the store that includes the thunk middleware types, and use that with `useDispatch`. Adding a pre-typed `useDispatch` hook keeps you from forgetting to import `AppDispatch` where it's needed.

**Previous behavior**
Styling was set up using traditional CSS. We commented that out as Cristian's upcoming PR will be implementing styled components. If you run `npm start` after pulling in this PR. Don't be alarmed if the homepage is bare.

**Expected behavior**
Redux Toolkit is set up for us to handle state for the `plantType` further implementation will be needed for other areas of state. However, the code is mostly similar. 


