### PR TITLE
Removed jest from typescript config

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node", "@types/jest"]
+    "types": ["node"]
   },
   "include": [
     "./src/**/*",


### PR DESCRIPTION
Modified `tsconfig.json` file to avoid "jest" building errors.
