### PR TITLE
Footer

### DIFF
--- a/client/src/components/HomePageComponents/FooterSection.tsx
+++ b/client/src/components/HomePageComponents/FooterSection.tsx
@@ -14,11 +14,11 @@ const FooterContainer = styled.div`
   background: linear-gradient(-45deg, #f0ead2, #adc178, #adc178, #6c584c);
   height: 25vh;
   color: white;
+`;
 
-  h1{
-    color: #FFFFFF;
-    text-shadow: #474747 3px 2px 2px;
-  }
+const FooterHeading = styled.h1`
+  color: #FFFFFF;
+  text-shadow: #474747 3px 2px 2px;
 `;
 
 const GithubIcon = styled.a`
@@ -36,16 +36,16 @@ const FooterSection: React.FC = () => {
 
   return (
     <FooterContainer>
-      <h1>Looking for ways to contribute?</h1>
+      <FooterHeading>Looking for ways to contribute?</FooterHeading>
       <h3>Check out our Repo below!</h3>
-      <GithubIcon href = "https://github.com/Los-Terremotos/GreenPets">
-                    {" "}
-                    <FontAwesomeIcon
-                      className="icon"
-                      icon={faGithub}
-                      style={{ color: "black" }}
-                    />
-                  </GithubIcon>
+      <GithubIcon href="https://github.com/Los-Terremotos/GreenPets">
+        {" "}
+        <FontAwesomeIcon
+          className="icon"
+          icon={faGithub}
+          style={{ color: "black" }}
+        />
+      </GithubIcon>
     </FooterContainer>
   )
 };

--- a/client/src/components/HomePageComponents/FooterSection.tsx
+++ b/client/src/components/HomePageComponents/FooterSection.tsx
@@ -18,9 +18,9 @@ const FooterSection: React.FC = () => {
 
   return (
     <FooterContainer>
-      <h1>Footer section</h1>
-      <h3>Add how to contact or how to contribute information</h3>
-      <h3>Add links to docs or github</h3>
+      <h1>Looking for ways to contribute?</h1>
+      <h3>Check out our Repo on github!</h3>
+      <a href = "https://github.com/Los-Terremotos/GreenPets">Github</a>
     </FooterContainer>
   )
 };

--- a/client/src/components/HomePageComponents/FooterSection.tsx
+++ b/client/src/components/HomePageComponents/FooterSection.tsx
@@ -1,16 +1,34 @@
+import { faGithub } from "@fortawesome/free-brands-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import styled from "styled-components";
 
 
 const FooterContainer = styled.div`
   width: 100%;
-  height: 25vh;
   background-color: #75472F;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  background: linear-gradient(-45deg, #f0ead2, #adc178, #adc178, #6c584c);
+  height: 25vh;
+  color: white;
+
+  h1{
+    color: #FFFFFF;
+    text-shadow: #474747 3px 2px 2px;
+  }
 `;
+
+const GithubIcon = styled.a`
+  font-size: 50px;
+
+  :hover{
+    color: #ffdab9;
+  }
+
+`
 
 
 const FooterSection: React.FC = () => {
@@ -19,8 +37,15 @@ const FooterSection: React.FC = () => {
   return (
     <FooterContainer>
       <h1>Looking for ways to contribute?</h1>
-      <h3>Check out our Repo on github!</h3>
-      <a href = "https://github.com/Los-Terremotos/GreenPets">Github</a>
+      <h3>Check out our Repo below!</h3>
+      <GithubIcon href = "https://github.com/Los-Terremotos/GreenPets">
+                    {" "}
+                    <FontAwesomeIcon
+                      className="icon"
+                      icon={faGithub}
+                      style={{ color: "black" }}
+                    />
+                  </GithubIcon>
     </FooterContainer>
   )
 };


### PR DESCRIPTION
## Overview

**Footer in Homepage**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Included a footer section on the home page that will include an icon link to our GitHub repository.

**Ticket Item**
Footer Component [#72](https://github.com/Los-Terremotos/GreenPets/issues/72)

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**
1. Navigate to the client folder in the terminal
2. Run `npm run start`
3. Navigate to localhost
4. Scroll down to the bottom and you should see a footer section navigating you to the repo of this project
   
**Previous behavior**
A default footer section that was meant as a placeholder

**Expected behavior**
For a footer section to be included at the bottom of the page where it can navigate the user to the Github's repo for this project.

**Screenshots & Videos**
![image](https://github.com/Los-Terremotos/GreenPets/assets/75650780/fb55b710-257e-4483-9293-78c4573c04d0)


