### PR TITLE
Endpoint fetch error

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,7 +44,7 @@ async function startServer() {
   // }
   // Set up our Express middleware to handle CORS, body parsing, and our expressMiddleware function
   app.use(
-    '/graphql', // <- declare endpoint for graphQL path
+    '/', // <- declare endpoint for graphQL path
     cors(),
     express.json(),
     // expressMiddleware accepts the same arguments as an Apollo Server instance and optional configuration options


### PR DESCRIPTION
## Overview

**Endpoint Fetch Error**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
This change is to fix the cors error that was happening which was not allowing us to fetch the data from the API when the user finished the questions. Changed the endpoint in the app.use from /graphql to / and now we are able to fetch and display the results.

**Ticket Item**

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**
1. Open server/src/index.ts
2. In the app.use method replace "/" with "/graphql"
3. Now run the client and server
4. Go to localhost
5. Click the get started button 
6. Go through the questions
7. You should now see an Apollo error displayed
   
**Previous behavior**
We were getting an Apollo failed to fetch error along with an error regarding cors in the developer tools console. This was not allowing us to fetch and display the plant list from the api.

**Expected behavior**
Now we should be able to get the list of plants after a user finishes the series of questions.
