### PR TITLE
GetStarted on Mobile

### DIFF
--- a/client/src/components/Questions.tsx
+++ b/client/src/components/Questions.tsx
@@ -41,7 +41,8 @@ const ButtonContainer = styled.div`
 `;
 const Button = styled.button<{id : string, $currentQuestion : string}>`
   height: 150px;
-  width: 300px;
+  width: 100%;
+  max-width: 300px;
   background-color: floralwhite;
   color: ${DarkGreyGreen.primary1.color};
   border-radius: 20px;
@@ -63,6 +64,10 @@ const Button = styled.button<{id : string, $currentQuestion : string}>`
     background-color: ${DarkGreyGreen.primary1.color};
     color: floralwhite;
   }
+
+  @media(max-width: 425px){
+    height:100px;
+  }
 `;
 
 const PrevButton = styled.a`
@@ -74,6 +79,10 @@ const PrevButton = styled.a`
   &:hover{
     color: ${DarkGreyGreen.primary2.color};
   }
+
+  @media(max-width: 425px){
+    height:10%;
+  }
 `
 const NextButton = styled.a`
   grid-area: next;
@@ -83,6 +92,9 @@ const NextButton = styled.a`
 
   &:hover{
     color: ${DarkGreyGreen.primary2.color};
+  }
+  @media(max-width: 425px){
+    height:10%;
   }
 `;
 


### PR DESCRIPTION
## Overview

**Get Started Mobile Styling**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
I found the Get Started page's mobile style to be not mobile-friendly. I reduced the size of the option buttons as well as the previous and next buttons on smaller viewports. Replaced width values that used pixel values to use percentages.

**Ticket Item**

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**
1. Open the project 
2. Run 'npm run start' in the client folder
3. Go to localhost
4. Navigate to the get-started page on a smaller viewport (375px)
5. You will now see the buttons are smaller and more viewable on mobile

   
**Previous behavior**
Buttons on the get started page were too big on smaller viewports which made the page less mobile friendly

**Expected behavior**
Buttons are now smaller which means the get started page is more mobile friendly.

**Screenshots & Videos**
![image](https://github.com/Los-Terremotos/GreenPets/assets/75650780/ce5e37b0-e1d6-4091-af45-ce9723d2849d)

