### PR TITLE
Result mobile

### DIFF
--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -28,6 +28,10 @@ const ModalContainer = styled.div`
   left: 0;
   background-color: rgba(0, 0, 0, 0.25);
   backdrop-filter: blur(4px);
+
+  @media(max-width: 768px){
+    top: 30px;
+  }
 `;
 
 

--- a/client/src/components/ResultsPageComponents/ContentTabs.tsx
+++ b/client/src/components/ResultsPageComponents/ContentTabs.tsx
@@ -39,6 +39,7 @@ const ContentWrapper = styled.div`
 
   @media(max-width: 768px){
     flex-direction: column;
+    gap: 0;
   }
 `;
 

--- a/client/src/components/ResultsPageComponents/ContentTabs.tsx
+++ b/client/src/components/ResultsPageComponents/ContentTabs.tsx
@@ -36,6 +36,10 @@ const ContentWrapper = styled.div`
   width: 100%;
   justify-content: space-between;
   gap: 30px;
+
+  @media(max-width: 768px){
+    flex-direction: column;
+  }
 `;
 
 const TabList = styled.div`

--- a/client/src/components/ResultsPageComponents/Results.tsx
+++ b/client/src/components/ResultsPageComponents/Results.tsx
@@ -37,11 +37,15 @@ const Card = styled.div`
 	border-radius: 10px;
 	margin: 10px;
 	box-shadow: 5px 5px 10px black;
+
+	@media(max-width: 425px){
+		width: 50%;
+	}
 `;
 
 const Image = styled.img`
 	border-radius: 10px;
-	margin-top: 10px;
+	margin-top: 25px;
 	box-shadow: 1px 1px 4px black;
 	width: 90%;
 `;

--- a/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
+++ b/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
@@ -46,6 +46,10 @@ const DetailTitle = styled.h1`
   display: inline-block;
   margin-bottom: 0.5rem;
   transition: background-color 0.5s ease, color 0.5s ease;
+
+  @media(max-width: 768px){
+    font-size: 27px;
+  }
 `;
 
 const DetailContentContainer = styled.div`

--- a/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
+++ b/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
@@ -50,7 +50,7 @@ const DetailContentContainer = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   margin: 2rem 2rem;
-  padding: 0 2rem;
+  // padding: 0 2rem;
   box-shadow: 1px 1px 4px black;
   background-color: floralwhite; // to match bg color of testimonial cards
   color: #304D30; // dark forest green to match title color

--- a/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
+++ b/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
@@ -22,6 +22,10 @@ const DetailCardContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  @media(max-width: 768px){
+    height: 797px;
+  }
 `;
 
 

--- a/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
+++ b/client/src/components/ResultsPageComponents/ResultsDetailCard.tsx
@@ -24,7 +24,7 @@ const DetailCardContainer = styled.div`
   align-items: center;
 
   @media(max-width: 768px){
-    height: 797px;
+    height: 90%;
   }
 `;
 

--- a/client/src/components/ResultsPageComponents/ViewMore.tsx
+++ b/client/src/components/ResultsPageComponents/ViewMore.tsx
@@ -12,7 +12,8 @@ import { fetchCareGuides } from "../../utils/fetchCareGuides";
 
 const ViewMoreBtn = styled.button`
   font-size: 1em;
-  margin: 1em;
+  // margin: 1em;
+  margin-top: 25px;
   padding: 0.25em 1em;
   height: 40px;
   width: 120px;


### PR DESCRIPTION
## Overview

**Result Mobile**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
- Added more margin between title and image on the result cards as I was seeing the title and image collide.
- Increased the size of the cards on smaller mobile sizes
- Removed padding on inner modal container due to the size of the inner container being bigger than the outer container and is especially noticeable on mobile
- Changed the links to appear on top of the body of the more details modal to give the modal body more room and be more accessible on mobile.
- Increased height of modal on mobile to give body text more room to be shown
- Reduced font size on mobile to give more room for body text
- After increasing the size of the height of the modal I needed to adjust the modal top values on the top modal due to the top and bottom portions of the modal being cut off.



**Ticket Item**
FE/ Results page responsiveness for mobile / tablets #120

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**
1. Open the project and go to the resultMobile branch
2. You may need to run 'npm install' in the terminal
4. Navigate to the client folder in the terminal
5. Run 'npm run start'
6. Open a separate terminal and navigate to the server folder
7. run 'npm run dev'
8. Open up a browser and navigate to the application on localhost
9. Navigate to the questionnaire section of the application and go through the questions
10. You will now see the result page
11. You can then resize the window or look at smaller views in the Chrome dev tools
12. To open the modal tap/click on view more button on one of the cards
   
**Previous behavior**
Styling for the results page was not mobile friendly making it difficult to read/interact with on mobile

**Expected behavior**
The results page should now be more accessible via mobile/tablet

**Screenshots & Videos**
![image](https://github.com/Los-Terremotos/GreenPets/assets/75650780/50152955-e662-4767-a6ee-c9af4090a814)
![image](https://github.com/Los-Terremotos/GreenPets/assets/75650780/43de59da-37be-4a48-8a1a-0b2b7e066858)
![image](https://github.com/Los-Terremotos/GreenPets/assets/75650780/85838232-8158-480b-b7f7-755fbd21b16d)
![image](https://github.com/Los-Terremotos/GreenPets/assets/75650780/8cd95689-d8a8-46fd-9197-74febee6baae)

